### PR TITLE
Redirect to dashboard after login

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -8,7 +8,8 @@ export function Header() {
   const { status, data } = useSession();
 
   async function handleLogin() {
-    await signIn();
+    // Redirect the user to the dashboard after a successful login
+    await signIn('google', { callbackUrl: '/dashboard' });
   }
 
   async function handleLogout() {


### PR DESCRIPTION
## Summary
- update login handler so Google sign-in callback goes to `/dashboard`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb32bddcc832b907203ecfce6b69e