### PR TITLE
Add customer editing feature

### DIFF
--- a/src/app/api/customer/route.ts
+++ b/src/app/api/customer/route.ts
@@ -75,3 +75,38 @@ export async function POST(request: Request){
   }
 
 }
+
+// Rota para atualizar um cliente
+export async function PATCH(request: Request){
+  const session = await getServerSession(authOptions);
+
+  if(!session || !session.user){
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 })
+  }
+
+  const { id, name, email, phone, address } = await request.json();
+
+  if(!id){
+    return NextResponse.json({ error: "Failed update customer" }, { status: 400 })
+  }
+
+  try{
+    await prismaClient.customer.update({
+      where:{
+        id: id as string
+      },
+      data:{
+        name,
+        email,
+        phone,
+        address: address ? address : ""
+      }
+    })
+
+    return NextResponse.json({ message: "Cliente atualizado com sucesso!" })
+
+  }catch(err){
+    return NextResponse.json({ error: "Failed update customer" }, { status: 400 })
+  }
+
+}

--- a/src/app/dashboard/customer/components/card/index.tsx
+++ b/src/app/dashboard/customer/components/card/index.tsx
@@ -34,12 +34,20 @@ export function CardCustomer({ customer }: { customer: CustomerProps }) {
       <p><a className="font-bold">Email:</a> {customer.email}</p>
       <p><a className="font-bold">Telefone:</a> {customer.phone}</p>
 
-      <button
-        className="bg-red-500 px-4 rounded text-white mt-2 self-start"
-        onClick={handleDeleteCustomer}
-      >
-        Deletar
-      </button>
+      <div className="flex gap-2 mt-2">
+        <button
+          className="bg-red-500 px-4 rounded text-white self-start"
+          onClick={handleDeleteCustomer}
+        >
+          Deletar
+        </button>
+        <a
+          href={`/dashboard/customer/edit/${customer.id}`}
+          className="bg-blue-500 px-4 rounded text-white self-start"
+        >
+          Editar
+        </a>
+      </div>
     </article>
   )
 }

--- a/src/app/dashboard/customer/components/form/edit.tsx
+++ b/src/app/dashboard/customer/components/form/edit.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Input } from '@/components/input'
+import { api } from '@/lib/api'
+import { useRouter } from 'next/navigation'
+import { CustomerProps } from '@/utils/customer.type'
+
+const schema = z.object({
+  name: z.string().min(1, "O campo nome é obrigatório"),
+  email: z.string().email("Digite um email valido.").min(1, "O email é obrigatório."),
+  phone: z.string().refine((value) => {
+    return /^(?:\(\d{2}\)\s?)?\d{9}$/.test(value) || /^\d{2}\s\d{9}$/.test(value) || /^\d{11}$/.test(value)
+  }, {
+    message: "O numero de telefone deve estar (DD) 999999999"
+  }),
+  address: z.string(),
+})
+
+type FormData = z.infer<typeof schema>
+
+export function EditCustomerForm({ customer }: { customer: CustomerProps }) {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: customer.name,
+      email: customer.email,
+      phone: customer.phone,
+      address: customer.address || "",
+    }
+  })
+
+  const router = useRouter();
+
+  async function handleUpdateCustomer(data: FormData) {
+    await api.patch("/api/customer", {
+      id: customer.id,
+      name: data.name,
+      phone: data.phone,
+      email: data.email,
+      address: data.address,
+    })
+
+    router.refresh()
+    router.replace("/dashboard/customer")
+  }
+
+  return (
+    <form className="flex flex-col mt-6" onSubmit={handleSubmit(handleUpdateCustomer)}>
+      <label className="mb-1 text-lg font-medium">Nome completo</label>
+      <Input
+        type="text"
+        name="name"
+        placeholder="Digite o nome completo"
+        error={errors.name?.message}
+        register={register}
+      />
+
+      <section className="flex gap-2 my-2 flex-col sm:flex-row">
+        <div className="flex-1">
+          <label className="mb-1 text-lg font-medium">Telefone</label>
+          <Input
+            type="text"
+            name="phone"
+            placeholder="Exemplo (DD) 999101900"
+            error={errors.phone?.message}
+            register={register}
+          />
+        </div>
+
+        <div className="flex-1">
+          <label className="mb-1 text-lg font-medium">Email</label>
+          <Input
+            type="email"
+            name="email"
+            placeholder="Digite o email..."
+            error={errors.email?.message}
+            register={register}
+          />
+        </div>
+      </section>
+
+      <label className="mb-1 text-lg font-medium">Endereço completo</label>
+      <Input
+        type="text"
+        name="address"
+        placeholder="Digite o endereço do cliente..."
+        error={errors.address?.message}
+        register={register}
+      />
+
+      <button
+        type="submit"
+        className="bg-blue-500 my-4 px-2 h-11 rounded text-white font-bold"
+      >
+        Salvar
+      </button>
+
+    </form>
+  )
+}

--- a/src/app/dashboard/customer/edit/[id]/page.tsx
+++ b/src/app/dashboard/customer/edit/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { Container } from "@/components/container";
+import { authOptions } from "@/lib/auth";
+import { getServerSession } from "next-auth";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import prismaClient from "@/lib/prisma";
+import { EditCustomerForm } from "../../components/form/edit";
+
+interface PageProps {
+  params: { id: string }
+}
+
+export default async function EditCustomer({ params }: PageProps) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user) {
+    redirect("/");
+  }
+
+  const customer = await prismaClient.customer.findFirst({
+    where: {
+      id: params.id,
+      userId: session.user.id
+    }
+  });
+
+  if (!customer) {
+    redirect("/dashboard/customer");
+  }
+
+  return (
+    <Container>
+      <main className="flex flex-col mt-9 mb-2">
+        <div className="flex items-center gap-3">
+          <Link href="/dashboard/customer" className="bg-gray-900 px-4 py-1 text-white rounded">
+            Voltar
+          </Link>
+          <h1 className="text-3xl font-bold">Editar cliente</h1>
+        </div>
+
+        <EditCustomerForm customer={customer} />
+      </main>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- support editing customers via PATCH `/api/customer`
- add client form component for editing customers
- show edit button in customer list
- add edit customer page
- remove alert after updating customer

## Testing
- `npm install` *(fails: ENETUNREACH)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb8e25e54832b8099adfb3a16c171